### PR TITLE
new discard() method

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -295,6 +295,17 @@ let nums = new SuperSet([0, 1, 2]);
 nums.update([2, 4, 6]);  // → SuperSet { 0, 1, 2, 4, 6 }
 ```
 
+## `discard(iterable)`
+
+The discard() method deletes the iterable elements from the set and return the updated elements.
+
+### Example
+
+```js
+let nums = new SuperSet([1, 2, 3, 4]);
+nums.discard([1, 3]); // → SuperSet { 2, 4 }
+```
+
 ---
 
 Parts of this documentation are adapted from [MDN][mdn-url].

--- a/docs/index.md
+++ b/docs/index.md
@@ -297,7 +297,7 @@ nums.update([2, 4, 6]);  // → SuperSet { 0, 1, 2, 4, 6 }
 
 ## `discard(iterable)`
 
-The discard() method deletes the iterable elements from the set and return the updated elements.
+The discard() method deletes the iterable elements from the data set and returns the updated elements.
 
 ### Example
 

--- a/index.js
+++ b/index.js
@@ -286,6 +286,20 @@ class SuperSet extends Set {
     symmetricDiff(otherSetObj) {
         return new SuperSet(xorGen(this, otherSetObj));
     }
+
+    /**
+     * The discard() method deletes the iterable elements from the set and return the updated elements.
+     *
+     * @param {Iterable} iterable It contains iterable elements to be deleted from the current set.
+     * @returns {SuperSet} It returns the current state of the set after the deleted elements.
+     */
+
+    discard(iterable) {
+        for (const itm of iterable)
+            this.delete(itm);
+
+        return this;
+    }
 }
 
 module.exports = SuperSet;

--- a/test/superset.spec.js
+++ b/test/superset.spec.js
@@ -219,5 +219,19 @@ describe("SuperSet", () => {
 
             expect(Array.from(result)).to.eql([2]);
         });
+
+        it("should delete undefined elements and return updated elements.", () => {
+            const result = testSet.discard([7]);
+
+            expect(Array.from(result)).to.eql([1, 2, 3]);
+        });
+
+        it("should delete again same elements in an iterable way and return current elements.", () => {
+            const result = testSet.discard([1]);
+            expect(Array.from(result)).to.eql([2, 3]);
+
+            const sameResult = testSet.discard([1]);
+            expect(Array.from(sameResult)).to.eql([2, 3]);
+        });
     });
 });

--- a/test/superset.spec.js
+++ b/test/superset.spec.js
@@ -212,4 +212,12 @@ describe("SuperSet", () => {
             expect(Array.from(result)).to.eql([1, 4, 5]);
         });
     });
+
+    describe("discard", () => {
+        it("should delete elements in an iterable way and return updated elements.", () => {
+            const result = testSet.discard([1, 3]);
+
+            expect(Array.from(result)).to.eql([2]);
+        });
+    });
 });


### PR DESCRIPTION
The discard() method deletes the iterable elements from the data set and returns the updated elements.