### PR TITLE
fix: upgrade GitHub Actions to Node 24 and fix corepack blocking npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         node: ['20', '22']
     name: Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -30,9 +30,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: pnpm
@@ -41,7 +41,7 @@ jobs:
       - name: Test with coverage
         run: pnpm test:ci
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -52,9 +52,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: pnpm
@@ -63,7 +63,7 @@ jobs:
       - name: Pack tarball
         run: npm pack
       - name: Upload tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-tarball
           path: '*.tgz'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     timeout-minutes: 15
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -34,7 +34,7 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: release/${{ steps.inputs.outputs.version }}
           token: ${{ steps.app-token.outputs.token }}
@@ -45,12 +45,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Upgrade npm for OIDC trusted publishing
         run: |
+          corepack disable
           npm install -g npm@latest
           npm --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,13 @@ jobs:
       contents: write
       issues: write
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Fixes the publish workflow failure at "Upgrade npm for OIDC trusted publishing" and eliminates Node.js 20 deprecation warnings across all workflows.

## Changes

- **Fix corepack blocking npm in publish workflow**: Adds `corepack disable` before `npm install -g npm@latest`. Corepack (bundled with Node 22) was intercepting the `npm` command and blocking it because `package.json` declares `packageManager: pnpm@10.28.0`.
- **Upgrade all GitHub Actions to Node 24 runtime versions**:
  - `actions/checkout` v4 → v6
  - `actions/create-github-app-token` v1 → v3
  - `actions/setup-node` v4 → v6
  - `actions/upload-artifact` v4 → v7
  - `codecov/codecov-action` v5 → v6

This eliminates the warning: *"Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."*