### PR TITLE
fix: use Node 24 in publish workflow instead of upgrading npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,13 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: |
-          corepack disable
-          npm install -g npm@latest
-          npm --version
+          node-version: 24
 
       - name: Install Craft
         run: |


### PR DESCRIPTION
## Summary

Fixes the publish workflow failure where `npm install -g npm@latest` crashes with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'`. Node 22's bundled npm 10.9.7 corrupts itself when self-upgrading to npm 11.x.

## Changes

- Switches publish workflow from Node 22 to Node 24, which ships with npm 11.x natively
- Removes the "Upgrade npm for OIDC trusted publishing" step entirely — no longer needed since npm 11.x supports OIDC out of the box